### PR TITLE
Fix GitHub Actions workflows

### DIFF
--- a/.github/workflows/scheduled_generate_markdown.yml
+++ b/.github/workflows/scheduled_generate_markdown.yml
@@ -8,11 +8,11 @@ jobs:
     name: generate README.md with starred
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/scheduled_link_check.yml
+++ b/.github/workflows/scheduled_link_check.yml
@@ -10,15 +10,15 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: check links with lychee-action
-        uses: lycheeverse/lychee-action@v1.0.8
+        uses: lycheeverse/lychee-action@v1
         with:
           args: --verbose --no-progress **/*.md **/*.html
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: upload lychee-action output artifact
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         with:
           name: lychee-action-output
           path: ./lychee/out.md


### PR DESCRIPTION
Updated GitHub Actions workflows to use modern versions of `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, and `lycheeverse/lychee-action` to avoid deprecation warnings and ensure compatibility.

---
*PR created automatically by Jules for task [8314835852019976545](https://jules.google.com/task/8314835852019976545) started by @arbal*